### PR TITLE
read data model csv as reactive object

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,1 +1,3 @@
+^renv$
+^renv\.lock$
 ^\.github$

--- a/global.R
+++ b/global.R
@@ -30,7 +30,7 @@ truncated_values <- JS("
 #' @export
 format_dict_table <- function(data_model_url) {
 
-  data_model <- read.csv(url(data_model_url))
+  data_model <- reactive(read.csv(url(data_model_url)))
 
   col_attribs <- data_model |>
     dplyr::filter(Parent == 'ManifestColumn') |>

--- a/global.R
+++ b/global.R
@@ -30,7 +30,7 @@ truncated_values <- JS("
 #' @export
 format_dict_table <- function(data_model_url) {
 
-  data_model <- reactive(read.csv(url(data_model_url)))
+  data_model <- read.csv(url(data_model_url))
 
   col_attribs <- data_model |>
     dplyr::filter(Parent == 'ManifestColumn') |>

--- a/server.R
+++ b/server.R
@@ -3,13 +3,14 @@ server <- function(input, output, session) {
   # Get data model csv and re-format for dictionary app
   # use reactive expression to get latest version of data model
   dict_table <- reactive({
-    format_dict_table(data_model_url)
+    df <- format_dict_table(data_model_url)
+    as.data.frame(df)  # Ensure the result is a data frame
   })
 
   ## Create table to display
   output$dictionary_table <- renderReactable({
     reactable(
-      dict_table,
+      dict_table(),
       groupBy = "Column",
       searchable = TRUE,
       sortable = TRUE,

--- a/server.R
+++ b/server.R
@@ -1,7 +1,10 @@
 server <- function(input, output, session) {
 
   # Get data model csv and re-format for dictionary app
-  dict_table <- format_dict_table(data_model_url)
+  # use reactive expression to get latest version of data model
+  dict_table <- reactive({
+    format_dict_table(data_model_url)
+  })
 
   ## Create table to display
   output$dictionary_table <- renderReactable({


### PR DESCRIPTION
use `shiny::reactive` when calling `read.csv` on the data model url to always pull the latest version of the production data model into the app when a user loads it.